### PR TITLE
cleaned up some duplicate logs in paramValidators.go

### DIFF
--- a/manager/paramValidators.go
+++ b/manager/paramValidators.go
@@ -20,9 +20,10 @@ package manager
 
 import (
 	"fmt"
+	"log"
+
 	"github.com/whiteblock/genesis/db"
 	"github.com/whiteblock/genesis/util"
-	"log"
 )
 
 func validateResources(details *db.DeploymentDetails) error {
@@ -38,14 +39,13 @@ func validateResources(details *db.DeploymentDetails) error {
 
 func validateNumOfNodes(details *db.DeploymentDetails) error {
 	if details.Nodes > conf.MaxNodes {
-		err := fmt.Errorf("too many nodes: max of %d nodes", conf.MaxNodes)
-		return err
+		return fmt.Errorf("too many nodes: max of %d nodes", conf.MaxNodes)
 	}
 
 	if details.Nodes < 1 {
-		err := fmt.Errorf("must have at least 1 node")
-		return err
+		return fmt.Errorf("must have at least 1 node")
 	}
+
 	return nil
 }
 
@@ -53,7 +53,6 @@ func validateImages(details *db.DeploymentDetails) error {
 	for _, image := range details.Images {
 		err := util.ValidateCommandLine(image)
 		if err != nil {
-			log.Println(err)
 			return err
 		}
 	}
@@ -63,7 +62,6 @@ func validateImages(details *db.DeploymentDetails) error {
 func validateBlockchain(details *db.DeploymentDetails) error {
 	err := util.ValidateCommandLine(details.Blockchain)
 	if err != nil {
-		log.Println(err)
 		return err
 	}
 	return nil
@@ -71,43 +69,23 @@ func validateBlockchain(details *db.DeploymentDetails) error {
 
 func checkForNilOrMissing(details *db.DeploymentDetails) error {
 	if details.Servers == nil {
-		err := fmt.Errorf("servers cannot be null")
-		if err != nil {
-			log.Println(err)
-			return err
-		}
+		return fmt.Errorf("servers cannot be null")
 	}
 
 	if len(details.Servers) == 0 {
-		err := fmt.Errorf("servers cannot be empty")
-		if err != nil {
-			log.Println(err)
-			return err
-		}
+		return fmt.Errorf("servers cannot be empty")
 	}
 
 	if len(details.Blockchain) == 0 {
-		err := fmt.Errorf("blockchain cannot be empty")
-		if err != nil {
-			log.Println(err)
-			return err
-		}
+		return fmt.Errorf("blockchain cannot be empty")
 	}
 
 	if details.Images == nil {
-		err := fmt.Errorf("images cannot be null")
-		if err != nil {
-			log.Println(err)
-			return err
-		}
+		return fmt.Errorf("images cannot be null")
 	}
 
 	if len(details.Images) == 0 {
-		err := fmt.Errorf("images cannot be empty")
-		if err != nil {
-			log.Println(err)
-			return err
-		}
+		return fmt.Errorf("images cannot be empty")
 	}
 
 	return nil


### PR DESCRIPTION
there were some duplicate logs that were unnecessary within paramValidators.go so I cleaned them up and also formatted the imports. Also cleaned up some returns to be more concise.