### PR TITLE
removed recommendation to run genesis on a separate user

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ https://camo.githubusercontent.com/915b7be44ada53c290eb157634330494ebe3e30a/6874
 [![Gitter](https://badges.gitter.im/whiteblock-io/community.svg)](https://gitter.im/whiteblock-io/community?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 
 # Overview
-The whiteblock platform allows users to provision multiple fully-functioning nodes over which they have complete control within a private test network 
+The Whiteblock platform allows users to provision multiple fully-functioning nodes over which they have complete control within a private test network 
 
 # REST API
 Documentation for the REST API can be found [here](rest.md). 
@@ -33,10 +33,7 @@ set environment variables to allow SSH commands:
 6. run step 1. again and there should be a docker help output
 
 ### Build Genesis
-It is recommended to run genesis on a separate user account from the main user account 
-* create a separate new user (this may have to be done manually in system preferences)
-* set up a [`$GOPATH`](https://medium.com/@AkyunaAkish/setting-up-a-golang-development-environment-mac-os-x-d58e5a7ea24f) on the the new user account
-* `go` ( makes sure go is already installed )
+* set up a [go development environment](https://medium.com/@AkyunaAkish/setting-up-a-golang-development-environment-mac-os-x-d58e5a7ea24f)
 * `go get github.com/whiteblock/genesis`
 * `cd $GOPATH/src/github.com/whiteblock/genesis`
 * `go build`


### PR DESCRIPTION
removed recommendation to run genesis on a separate user in README, but left recommendation to set up a go development environment