### PR TITLE
Log to different files for the testnet

### DIFF
--- a/blockchains/artemis/artemis.go
+++ b/blockchains/artemis/artemis.go
@@ -28,6 +28,7 @@ import (
 	"github.com/whiteblock/genesis/ssh"
 	"github.com/whiteblock/genesis/testnet"
 	"github.com/whiteblock/genesis/util"
+	"reflect"
 	"strings"
 )
 
@@ -109,8 +110,14 @@ func build(tn *testnet.TestNet) error {
 	tn.BuildState.SetBuildStage("Starting Artemis")
 	err = helpers.AllNodeExecCon(tn, func(client ssh.Client, server *db.Server, node ssh.Node) error {
 		defer tn.BuildState.IncrementBuildProgress()
-
-		artemisCmd := `artemis -c /artemis/config/config.toml 2>&1 | tee /output.log`
+		var logFolder string
+		obj := tn.CombinedDetails.Params["logFolder"]
+		if obj != nil && reflect.TypeOf(obj).Kind() == reflect.String {
+			logFolder = obj.(string)
+		} else {
+			logFolder = ""
+		}
+		artemisCmd := fmt.Sprintf("artemis -c /artemis/config/config.toml 2>&1 | tee %s/output%d.log", logFolder, node.GetAbsoluteNumber())
 
 		_, err := client.DockerExecd(node, "tmux new -s whiteblock -d")
 		if err != nil {

--- a/blockchains/prysm/prysm.go
+++ b/blockchains/prysm/prysm.go
@@ -98,8 +98,15 @@ func build(tn *testnet.TestNet) error {
 		if prometheusInstrumentationPort == "" {
 			prometheusInstrumentationPort = "8088"
 		}
+		var logFolder string
+		obj = tn.CombinedDetails.Params["logFolder"]
+		if obj != nil && reflect.TypeOf(obj).Kind() == reflect.String {
+			logFolder = obj.(string)
+		} else {
+			logFolder = ""
+		}
 
-		_, err = client.DockerExecd(node, fmt.Sprintf("/beacon-chain --monitoring-port=%s --no-discovery %s --log-file /output.log --p2p-priv-key /etc/identity.key", prometheusInstrumentationPort, peers))
+		_, err = client.DockerExecd(node, fmt.Sprintf("/beacon-chain --monitoring-port=%s --no-discovery %s --log-file %s/output-%d.log --p2p-priv-key /etc/identity.key", prometheusInstrumentationPort, peers, logFolder, node.GetAbsoluteNumber()))
 		return err
 	})
 	return util.LogError(err)


### PR DESCRIPTION
This allows to log under the same folder, but different files, for each of the nodes of a testnet.

This will allow us to perform tests where we compare log file output.