### PR TITLE
Interop work for generic blockchain

### DIFF
--- a/protocols/generic/generic.go
+++ b/protocols/generic/generic.go
@@ -19,8 +19,13 @@
 package generic
 
 import (
+	"crypto/rand"
 	"fmt"
+	peer "github.com/libp2p/go-libp2p-peer"
+	log "github.com/sirupsen/logrus"
+	"path/filepath"
 
+	"github.com/libp2p/go-libp2p-crypto"
 	"github.com/whiteblock/genesis/db"
 	"github.com/whiteblock/genesis/protocols/helpers"
 	"github.com/whiteblock/genesis/protocols/registrar"
@@ -44,33 +49,64 @@ func init() {
 
 // build builds out a fresh new ethereum test network using geth
 func build(tn *testnet.TestNet) error {
-	tn.BuildState.SetBuildSteps(2 + tn.LDD.Nodes)
+	libp2p := tn.LDD.Params["libp2p"] == "true"
+	tn.BuildState.SetBuildSteps(3 + tn.LDD.Nodes)
+
+	tn.BuildState.SetBuildStage("Copying files inside the Docker containers")
 
 	tn.BuildState.IncrementBuildProgress()
 
-	tn.BuildState.SetBuildStage("Provisioning nodes")
+	p2pPort := 9000
 
-	staticNodes := make([]string, tn.LDD.Nodes)
+	tn.BuildState.SetBuildStage("Generating key pairs")
 
-	for i, node := range tn.Nodes {
-		staticNodes[i] = node.GetIP()
+	nodeKeyPairs := map[string]crypto.PrivKey{}
+	for _, node := range tn.Nodes {
+		prvKey, _, _ := crypto.GenerateKeyPairWithReader(crypto.RSA, 2048, rand.Reader)
+		nodeKeyPairs[node.ID] = prvKey
 	}
 
 	tn.BuildState.IncrementBuildProgress()
+	var params string
+
+	var startArguments map[string]interface{}
+	startArguments = tn.LDD.Params["args"].(map[string]interface{})
+	for key, param := range startArguments {
+		params += fmt.Sprintf(" --%s %v", key, param)
+	}
+
+	params += fmt.Sprintf(" --port %d", p2pPort)
 
 	err := helpers.AllNewNodeExecCon(tn, func(client ssh.Client, _ *db.Server, node ssh.Node) error {
-		var params string
+		files := tn.LDD.Params["files"].([]string)
+		for _, fileToCopy := range files {
+			err := client.Scp(fileToCopy, fmt.Sprintf("/launch/%s", filepath.Base(fileToCopy)))
+			if err != nil {
+				return util.LogError(err)
+			}
+		}
+		thisNodeParams := params + " --peers "
 
-		for key, param := range tn.LDD.Params {
-			params += fmt.Sprintf(" --%s %v", key, param)
+		for _, peerNode := range tn.Nodes {
+			if node.GetID() == peerNode.GetID() {
+				continue
+			}
+
+			if libp2p {
+				thisNodeParams += fmt.Sprintf(" /ip4/%s/tcp/%d/p2p/%s:%d", peerNode.IP, p2pPort, idString(nodeKeyPairs[peerNode.GetID()]), p2pPort)
+			} else {
+				thisNodeParams += fmt.Sprintf(" %s", peerNode.IP)
+			}
+			tn.BuildState.IncrementBuildProgress()
 		}
 
-		params += "--peers"
-		for _, peer := range staticNodes {
-			params += fmt.Sprintf(" %v", peer)
+		if libp2p {
+			thisNodeParams += fmt.Sprintf(" --identity %s", nodeKeyPairs[node.GetID()])
 		}
 
-		_, err := client.DockerExec(node, fmt.Sprintf("sh /start.sh %s", params))
+		log.WithField("args", thisNodeParams).Infof("Starting node %d", node.GetID())
+
+		_, err := client.DockerExec(node, fmt.Sprintf("sh /launch/start.sh %s", thisNodeParams))
 		if err != nil {
 			return util.LogError(err)
 		}
@@ -80,6 +116,14 @@ func build(tn *testnet.TestNet) error {
 	})
 
 	return err
+}
+
+func idString(k crypto.PrivKey) string {
+	pid, err := peer.IDFromPrivateKey(k)
+	if err != nil {
+		panic(err)
+	}
+	return pid.Pretty()
 }
 
 func add(tn *testnet.TestNet) error {

--- a/protocols/generic/generic.go
+++ b/protocols/generic/generic.go
@@ -104,7 +104,7 @@ func build(tn *testnet.TestNet) error {
 			thisNodeParams += fmt.Sprintf(" --identity %s", nodeKeyPairs[node.GetID()])
 		}
 
-		log.WithField("args", thisNodeParams).Infof("Starting node %d", node.GetID())
+		log.WithField("args", thisNodeParams).Infof("Starting node %s", node.GetID())
 
 		_, err := client.DockerExec(node, fmt.Sprintf("sh /launch/start.sh %s", thisNodeParams))
 		if err != nil {


### PR DESCRIPTION
Make generic able to take args and libp2p options
Allow selecting files on disk to be copied under /launch
Move /start.sh to /launch/start.sh