### PR TITLE
Add testnetID and orgID to DeploymentDetails

### DIFF
--- a/db/build.go
+++ b/db/build.go
@@ -21,6 +21,7 @@ package db
 import (
 	"encoding/json"
 	"fmt"
+
 	_ "github.com/mattn/go-sqlite3" //Bring db in
 	"github.com/whiteblock/genesis/util"
 )
@@ -162,7 +163,6 @@ func QueryBuilds(query string) ([]DeploymentDetails, error) {
 func GetAllBuilds() ([]DeploymentDetails, error) {
 	return QueryBuilds(fmt.Sprintf("SELECT testnet,servers,blockchain,nodes,image,params,resources,files,environment,logs,extras,kid FROM %s", BuildsTable))
 }
-
 
 //GetBuildByTestnet gets the build parameters based off testnet id
 func GetBuildByTestnet(id string) (DeploymentDetails, error) {

--- a/db/build.go
+++ b/db/build.go
@@ -25,54 +25,46 @@ import (
 	"github.com/whiteblock/genesis/util"
 )
 
-/*
-DeploymentDetails represents the data for the construction of a testnet.
-*/
+// DeploymentDetails represents the data for the construction of a testnet.
 type DeploymentDetails struct {
 	// ID will be included when it is queried from the database.
 	ID string `json:"id,omitempty"`
 
-	/*
-	   Servers: The ids of the servers to build on
-	*/
+	// TestNetID: The id of the provisioned testnet
+	TestNetID string `json:"testnetID"`
+
+	// OrgID: The id of the organization
+	OrgID string `json:"orgID"`
+
+	// Servers: The ids of the servers to build on
 	Servers []int `json:"servers"`
-	/*
-	   Blockchain: The blockchain to build.
-	*/
+
+	// Blockchain: The blockchain to build.
 	Blockchain string `json:"blockchain"`
-	/*
-	   Nodes:  The number of nodes to build
-	*/
+
+	// Nodes:  The number of nodes to build
 	Nodes int `json:"nodes"`
-	/*
-	   Image: The docker image to build off of
-	*/
+
+	// Image: The docker image to build off of
 	Images []string `json:"images"`
-	/*
-	   Params: The blockchain specific parameters
-	*/
+
+	// Params: The blockchain specific parameters
 	Params map[string]interface{} `json:"params"`
-	/*
-	   Resources: The resources per node
-	*/
+
+	// Resources: The resources per node
 	Resources []util.Resources `json:"resources"`
-	/*
-		Environments is the environment variables to be passed to each node.
-		If it doesn't exist for a node, it defaults first to index 0.
-	*/
+
+	// Environments is the environment variables to be passed to each node.
+	// If it doesn't exist for a node, it defaults first to index 0.
 	Environments []map[string]string `json:"environments"`
-	/*
-		Custom files for each node
-	*/
+
+	// Custom files for each node
 	Files []map[string]string `json:"files"`
-	/*
-		Logs to keep track of for each node
-	*/
+
+	// Logs to keep track of for each node
 	Logs []map[string]string `json:"logs"`
 
-	/*
-		Fairly Arbitrary extras for when additional customizations are added.
-	*/
+	// Fairly Arbitrary extras for when additional customizations are added.
 	Extras map[string]interface{} `json:"extras"`
 	jwt    string
 	kid    string
@@ -166,16 +158,13 @@ func QueryBuilds(query string) ([]DeploymentDetails, error) {
 	return builds, nil
 }
 
-/*
-GetAllBuilds gets all of the builds done by a user
-*/
+// GetAllBuilds gets all of the builds done by a user
 func GetAllBuilds() ([]DeploymentDetails, error) {
 	return QueryBuilds(fmt.Sprintf("SELECT testnet,servers,blockchain,nodes,image,params,resources,files,environment,logs,extras,kid FROM %s", BuildsTable))
 }
 
-/*
-GetBuildByTestnet gets the build parameters based off testnet id
-*/
+
+//GetBuildByTestnet gets the build parameters based off testnet id
 func GetBuildByTestnet(id string) (DeploymentDetails, error) {
 
 	details, err := QueryBuilds(fmt.Sprintf("SELECT testnet,servers,blockchain,nodes,image,params,resources,files,environment,logs,extras,kid FROM %s WHERE testnet = \"%s\"", BuildsTable, id))

--- a/deploy/build.go
+++ b/deploy/build.go
@@ -66,7 +66,7 @@ func buildLoggers(tn *testnet.TestNet, server *db.Server, node *db.Node) {
 			Type:            "logger",
 		}
 		tn.AddSideCar(scNode, index)
-		sidecarContainer := docker.NewSideCarContainer(&scNode, nil, util.Resources{}, server.SubnetID)
+		sidecarContainer := docker.NewSideCarContainer(&scNode, nil, util.Resources{}, server.SubnetID, tn.LDD)
 		sidecarContainer.AddVolume(
 			fmt.Sprintf("%s:%s",
 				filepath.Join(tn.GetNodeStoreDir(node), fmt.Sprintf("%d.log", i)),
@@ -159,7 +159,8 @@ func BuildNode(tn *testnet.TestNet, server *db.Server, node *db.Node) {
 		env = tn.LDD.Environments[node.AbsoluteNum]
 		log.WithFields(log.Fields{"env": env, "node": node.AbsoluteNum}).Trace("using custom env vars")
 	}
-	container := docker.NewNodeContainer(node, env, resource, server.SubnetID)
+
+	container := docker.NewNodeContainer(node, env, resource, server.SubnetID, tn.LDD)
 
 	logs := []string{conf.GetLogsOutputFile()}
 	extraLogs := registrar.GetAdditionalLogs(tn.LDD.Blockchain)

--- a/deploy/build.go
+++ b/deploy/build.go
@@ -115,7 +115,7 @@ func buildSideCars(tn *testnet.TestNet, server *db.Server, node *db.Node) {
 			Type:            sidecar,
 		}
 		tn.AddSideCar(scNode, i)
-		err = docker.Run(tn, server.ID, docker.NewSideCarContainer(&scNode, nil, util.Resources{}, server.SubnetID))
+		err = docker.Run(tn, server.ID, docker.NewSideCarContainer(&scNode, nil, util.Resources{}, server.SubnetID, tn.LDD))
 		if err != nil {
 			tn.BuildState.ReportError(err)
 			return

--- a/docker/container.go
+++ b/docker/container.go
@@ -100,14 +100,15 @@ type ContainerDetails struct {
 }
 
 // NewNodeContainer creates a representation of a container for a regular sideCar or regular node
-func NewNodeContainer(node *db.Node, env map[string]string, resources util.Resources, SubnetID int) Container {
+func NewNodeContainer(node *db.Node, env map[string]string, resources util.Resources, SubnetID int, deployDetails *db.DeploymentDetails) Container {
 	return &ContainerDetails{
 		Environment: env,
 		Image:       node.Image,
 		Node:        node.LocalID,
 		Resources:   resources,
 		Labels: map[string]string{
-			"testnetID": node.TestNetID, // TODO temp solution
+			"testnetID": deployDetails.TestNetID,
+			"orgID":     deployDetails.OrgID,
 		},
 		SubnetID:     SubnetID,
 		NetworkIndex: 0,
@@ -118,14 +119,15 @@ func NewNodeContainer(node *db.Node, env map[string]string, resources util.Resou
 }
 
 // NewSideCarContainer creates a representation of a container for a side car sideCar
-func NewSideCarContainer(sc *db.SideCar, env map[string]string, resources util.Resources, SubnetID int) Container {
+func NewSideCarContainer(sc *db.SideCar, env map[string]string, resources util.Resources, SubnetID int, deployDetails *db.DeploymentDetails) Container {
 	return &ContainerDetails{
 		Environment: env,
 		Image:       sc.Image,
 		Node:        sc.LocalID,
 		Resources:   resources,
 		Labels: map[string]string{
-			"testnetID": sc.TestnetID, // TODO temp solution
+			"testnetID": deployDetails.TestNetID,
+			"orgID":     deployDetails.OrgID,
 		},
 		SubnetID:     SubnetID,
 		NetworkIndex: sc.NetworkIndex,

--- a/docker/container_test.go
+++ b/docker/container_test.go
@@ -24,11 +24,16 @@ import (
 	"testing"
 
 	"github.com/whiteblock/genesis/db"
+	"github.com/whiteblock/genesis/testnet"
 	"github.com/whiteblock/genesis/util"
 )
 
 func TestNewNodeContainer(t *testing.T) {
 	testNode := new(db.Node)
+
+	ldd := new(db.DeploymentDetails)
+	ldd.TestNetID = "10"
+	ldd.OrgID = "10"
 
 	var tests = []struct {
 		node      *db.Node
@@ -47,7 +52,10 @@ func TestNewNodeContainer(t *testing.T) {
 				Image:        testNode.Image,
 				Node:         testNode.LocalID,
 				Resources:    util.Resources{},
-				Labels:       map[string]string{"testnetID": testNode.TestNetID},
+				Labels:       map[string]string{
+					"testnetID": ldd.TestNetID,
+					"orgID": ldd.OrgID,
+				},
 				SubnetID:     4,
 				NetworkIndex: 0,
 				Type:         ContainerType(0),
@@ -75,7 +83,10 @@ func TestNewNodeContainer(t *testing.T) {
 					Volumes: []string{},
 					Ports:   []string{},
 				},
-				Labels:       map[string]string{"testnetID": testNode.TestNetID},
+				Labels:       map[string]string{
+					"testnetID": ldd.TestNetID,
+					"orgID": ldd.OrgID,
+				},
 				SubnetID:     16,
 				NetworkIndex: 0,
 				Type:         ContainerType(0),
@@ -87,7 +98,7 @@ func TestNewNodeContainer(t *testing.T) {
 
 	for i, tt := range tests {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
-			if !reflect.DeepEqual(NewNodeContainer(tt.node, tt.env, tt.resources, tt.SubnetID), &tt.expected) {
+			if !reflect.DeepEqual(NewNodeContainer(tt.node, tt.env, tt.resources, tt.SubnetID, ldd), &tt.expected) {
 				t.Error("return value of NewNodeContainer does not match expected value")
 			}
 		})
@@ -95,13 +106,20 @@ func TestNewNodeContainer(t *testing.T) {
 }
 
 func BenchmarkNewNodeContainer(b *testing.B) {
+	tn := testnet.TestNet{}
+	tn.LDD = new(db.DeploymentDetails)
+
 	for n := 0; n < b.N; n++ {
-		NewNodeContainer(new(db.Node), map[string]string{}, util.Resources{}, 4)
+		NewNodeContainer(new(db.Node), map[string]string{}, util.Resources{}, 4, tn.LDD)
 	}
 }
 
 func TestNewSideCarContainer(t *testing.T) {
 	testSidecar := new(db.SideCar)
+
+	ldd := new(db.DeploymentDetails)
+	ldd.TestNetID = "10"
+	ldd.OrgID = "10"
 
 	var tests = []struct {
 		sideCar   *db.SideCar
@@ -120,7 +138,10 @@ func TestNewSideCarContainer(t *testing.T) {
 				Image:        testSidecar.Image,
 				Node:         testSidecar.LocalID,
 				Resources:    util.Resources{},
-				Labels:       map[string]string{"testnetID": testSidecar.TestnetID},
+				Labels:       map[string]string{
+					"testnetID": ldd.TestNetID,
+					"orgID": ldd.OrgID,
+				},
 				SubnetID:     4,
 				NetworkIndex: testSidecar.NetworkIndex,
 				Type:         ContainerType(1),
@@ -148,7 +169,10 @@ func TestNewSideCarContainer(t *testing.T) {
 					Volumes: []string{},
 					Ports:   []string{},
 				},
-				Labels:       map[string]string{"testnetID": testSidecar.TestnetID},
+				Labels:       map[string]string{
+					"testnetID": ldd.TestNetID,
+					"orgID": ldd.OrgID,
+				},
 				SubnetID:     16,
 				NetworkIndex: testSidecar.NetworkIndex,
 				Type:         ContainerType(1),
@@ -160,7 +184,7 @@ func TestNewSideCarContainer(t *testing.T) {
 
 	for i, tt := range tests {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
-			if !reflect.DeepEqual(NewSideCarContainer(tt.sideCar, tt.env, tt.resources, tt.SubnetID), &tt.expected) {
+			if !reflect.DeepEqual(NewSideCarContainer(tt.sideCar, tt.env, tt.resources, tt.SubnetID, ldd), &tt.expected) {
 				t.Error("return value of NewSideCarContainer does not match expected value")
 			}
 		})
@@ -168,8 +192,11 @@ func TestNewSideCarContainer(t *testing.T) {
 }
 
 func BenchmarkNewSideCarContainerContainer(b *testing.B) {
+	tn := testnet.TestNet{}
+	tn.LDD = new(db.DeploymentDetails)
+
 	for n := 0; n < b.N; n++ {
-		NewSideCarContainer(new(db.SideCar), map[string]string{}, util.Resources{}, 4)
+	NewSideCarContainer(new(db.SideCar), map[string]string{}, util.Resources{}, 4, tn.LDD)
 	}
 }
 
@@ -504,7 +531,11 @@ func BenchmarkContainerDetails_GetResources(b *testing.B) {
 func TestContainerDetails_GetLabels(t *testing.T) {
 	sc := new(db.SideCar)
 
-	testContainer := NewSideCarContainer(sc, map[string]string{}, util.Resources{}, 0)
+	ldd := new(db.DeploymentDetails)
+	ldd.TestNetID = "10"
+	ldd.OrgID = "10"
+
+	testContainer := NewSideCarContainer(sc, map[string]string{}, util.Resources{}, 0, ldd)
 
 	var tests = []struct {
 		cd       Container
@@ -517,7 +548,8 @@ func TestContainerDetails_GetLabels(t *testing.T) {
 		{
 			cd: testContainer,
 			expected: map[string]string{
-				"testnetID": sc.TestnetID,
+				"testnetID": ldd.TestNetID,
+				"orgID": ldd.OrgID,
 			},
 		},
 	}

--- a/docker/container_test.go
+++ b/docker/container_test.go
@@ -48,13 +48,13 @@ func TestNewNodeContainer(t *testing.T) {
 			resources: util.Resources{},
 			SubnetID:  4,
 			expected: ContainerDetails{
-				Environment:  map[string]string{},
-				Image:        testNode.Image,
-				Node:         testNode.LocalID,
-				Resources:    util.Resources{},
-				Labels:       map[string]string{
+				Environment: map[string]string{},
+				Image:       testNode.Image,
+				Node:        testNode.LocalID,
+				Resources:   util.Resources{},
+				Labels: map[string]string{
 					"testnetID": ldd.TestNetID,
-					"orgID": ldd.OrgID,
+					"orgID":     ldd.OrgID,
 				},
 				SubnetID:     4,
 				NetworkIndex: 0,
@@ -83,9 +83,9 @@ func TestNewNodeContainer(t *testing.T) {
 					Volumes: []string{},
 					Ports:   []string{},
 				},
-				Labels:       map[string]string{
+				Labels: map[string]string{
 					"testnetID": ldd.TestNetID,
-					"orgID": ldd.OrgID,
+					"orgID":     ldd.OrgID,
 				},
 				SubnetID:     16,
 				NetworkIndex: 0,
@@ -134,13 +134,13 @@ func TestNewSideCarContainer(t *testing.T) {
 			resources: util.Resources{},
 			SubnetID:  4,
 			expected: ContainerDetails{
-				Environment:  map[string]string{},
-				Image:        testSidecar.Image,
-				Node:         testSidecar.LocalID,
-				Resources:    util.Resources{},
-				Labels:       map[string]string{
+				Environment: map[string]string{},
+				Image:       testSidecar.Image,
+				Node:        testSidecar.LocalID,
+				Resources:   util.Resources{},
+				Labels: map[string]string{
 					"testnetID": ldd.TestNetID,
-					"orgID": ldd.OrgID,
+					"orgID":     ldd.OrgID,
 				},
 				SubnetID:     4,
 				NetworkIndex: testSidecar.NetworkIndex,
@@ -169,9 +169,9 @@ func TestNewSideCarContainer(t *testing.T) {
 					Volumes: []string{},
 					Ports:   []string{},
 				},
-				Labels:       map[string]string{
+				Labels: map[string]string{
 					"testnetID": ldd.TestNetID,
-					"orgID": ldd.OrgID,
+					"orgID":     ldd.OrgID,
 				},
 				SubnetID:     16,
 				NetworkIndex: testSidecar.NetworkIndex,
@@ -196,7 +196,7 @@ func BenchmarkNewSideCarContainerContainer(b *testing.B) {
 	tn.LDD = new(db.DeploymentDetails)
 
 	for n := 0; n < b.N; n++ {
-	NewSideCarContainer(new(db.SideCar), map[string]string{}, util.Resources{}, 4, tn.LDD)
+		NewSideCarContainer(new(db.SideCar), map[string]string{}, util.Resources{}, 4, tn.LDD)
 	}
 }
 
@@ -549,7 +549,7 @@ func TestContainerDetails_GetLabels(t *testing.T) {
 			cd: testContainer,
 			expected: map[string]string{
 				"testnetID": ldd.TestNetID,
-				"orgID": ldd.OrgID,
+				"orgID":     ldd.OrgID,
 			},
 		},
 	}

--- a/docker/docker_test.go
+++ b/docker/docker_test.go
@@ -316,10 +316,6 @@ func TestRun(t *testing.T) {
 	command := "docker run -itd --entrypoint /bin/sh --network wb_vlan0  --cpus 4 --memory 5000000 --ip 10.10.0.2 --hostname whiteblock-node0 --name whiteblock-node0 prysm:latest -l testnetID=10 -l orgID=10"
 	client.EXPECT().Run(command).AnyTimes()
 
-	fmt.Print("expected")
-	fmt.Println(command)
-	fmt.Println()
-
 	container := NewNodeContainer(node, map[string]string{}, util.Resources{Cpus: "4", Memory: "5MB"}, 10, ldd)
 
 	if err := Run(testNet, 0, container); err != nil {

--- a/docker/docker_test.go
+++ b/docker/docker_test.go
@@ -309,10 +309,18 @@ func TestRun(t *testing.T) {
 	node.TestNetID = "10"
 	node.Image = "prysm:latest"
 
-	command := "docker run -itd --entrypoint /bin/sh --network wb_vlan0  --cpus 4 --memory 5000000 --ip 10.10.0.2 --hostname whiteblock-node0 --name whiteblock-node0 prysm:latest -l testnetID=10"
+	ldd := new(db.DeploymentDetails)
+	ldd.TestNetID = "10"
+	ldd.OrgID = "10"
+
+	command := "docker run -itd --entrypoint /bin/sh --network wb_vlan0  --cpus 4 --memory 5000000 --ip 10.10.0.2 --hostname whiteblock-node0 --name whiteblock-node0 prysm:latest -l testnetID=10 -l orgID=10"
 	client.EXPECT().Run(command).AnyTimes()
 
-	container := NewNodeContainer(node, map[string]string{}, util.Resources{Cpus: "4", Memory: "5MB"}, 10)
+	fmt.Print("expected")
+	fmt.Println(command)
+	fmt.Println()
+
+	container := NewNodeContainer(node, map[string]string{}, util.Resources{Cpus: "4", Memory: "5MB"}, 10, ldd)
 
 	if err := Run(testNet, 0, container); err != nil {
 		t.Error("return value of Run does not match expected value")


### PR DESCRIPTION
* cleans up some of the comments in db/build.go for consistency
* adds `TestNetID` and `OrgID` as fields in the `DeploymentDetails` struct