### PR TITLE
call slack notify before executing remains teardown steps

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -108,11 +108,10 @@ pipeline {
     failure {
       sh "docker network prune --force"
       sh "docker volume prune --force"
-      script {
-        slackNotify(env.BRANCH_NAME == DEFAULT_BRANCH)
-      }
     }
     always {
+      // slack notify first to ignore teardown errors
+      slackNotify(env.BRANCH_NAME == DEFAULT_BRANCH)
       sh "kubectl config delete-context ${DEV_KUBE_CONTEXT} || true"
       sh "gcloud auth revoke || true"
       deleteDir()


### PR DESCRIPTION
This will reduce the number of false positives in the #alerts channel by deciding whether or not to notify before running the teardown steps

This will also get us notifications when the build is fixed